### PR TITLE
Hotfix: 2020-07-10

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -47,12 +47,13 @@
 
 <style>
 	footer {
+		width: 100%;
 		max-width: 53em;
 		position: relative;
 		display: grid;
 		gap: 0.5em;
 		padding: 3em 1em;
-		margin: 0 auto 3em;
+		margin: auto auto 3em;
 		text-align: center;
 		font-family: var(--aqua-monospace);
 		font-size: clamp(0.8em, 3vw, 1em);

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -30,7 +30,8 @@
 <style>
 	:global(#sapper) {
 		min-height: 100vh;
-		display: grid;
+		display: flex;
+		flex-direction: column;
 		font-family: var(--aqua-default);
 	}
 </style>


### PR DESCRIPTION
- Revert main div to flex so everything stays at the top
- Pushes footer to the bottom of the page if there's not enough content